### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/atye/gosrsbox.svg?branch=master)](https://travis-ci.org/atye/gosrsbox) [![Coverage Status](https://coveralls.io/repos/github/atye/gosrsbox/badge.svg?branch=master)](https://coveralls.io/github/atye/gosrsbox?branch=master)
+[![Build Status](https://travis-ci.org/atye/gosrsbox.svg?branch=master)](https://travis-ci.org/atye/gosrsbox) [![Coverage Status](https://coveralls.io/repos/github/atye/gosrsbox/badge.svg?branch=master&service=github)](https://coveralls.io/github/atye/gosrsbox?branch=master&service=github)
 
 gosrsbox is a client for the osrsbox-api; https://api.osrsbox.com.
 


### PR DESCRIPTION
coveralls badge not updating. could be a github cache issue. adding service param could fix it.

https://github.com/nansencenter/nansat/issues/240#issuecomment-408085868

https://github.com/lemurheavy/coveralls-public/issues/971#issuecomment-338942441