### PR TITLE
add get by wiki name

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,12 +12,16 @@ type OSRSBoxClient interface {
 	GetAllItems(ctx context.Context) ([]*Item, error)
 	// GetItemsByName returns a slice of items specified by name.
 	GetItemsByName(ctx context.Context, names ...string) ([]*Item, error)
+	// GetItemsByWikiName returns a slice of items specified by OSRS Wiki name.
+	GetItemsByWikiName(ctx context.Context, names ...string) ([]*Item, error)
 	// GetItemsWhere returns a slice of items from the supplied MongoDB query.
 	GetItemsWhere(ctx context.Context, query string) ([]*Item, error)
 	// GetAllMonsters returns a slice of all monsters.
 	GetAllMonsters(ctx context.Context) ([]*Monster, error)
 	// GetMonstersByName returns a slice of monsters specified by name.
 	GetMonstersByName(ctx context.Context, names ...string) ([]*Monster, error)
+	// GetMonstersByWikiName returns a slice of monsters specified by OSRS Wiki name.
+	GetMonstersByWikiName(ctx context.Context, names ...string) ([]*Monster, error)
 	// GetMonstersThatDrop returns a slice of monsters that drop the supplied item names.
 	// It returns monsters that drop any of the item names, not monsters that drop all of them.
 	GetMonstersThatDrop(ctx context.Context, names ...string) ([]*Monster, error)
@@ -65,6 +69,10 @@ func (c *client) GetItemsByName(ctx context.Context, names ...string) ([]*Item, 
 	return getItemsByName(ctx, c, names...)
 }
 
+func (c *client) GetItemsByWikiName(ctx context.Context, names ...string) ([]*Item, error) {
+	return getItemsByWikiName(ctx, c, names...)
+}
+
 func (c *client) GetItemsWhere(ctx context.Context, query string) ([]*Item, error) {
 	return getItemsWhere(ctx, c, query)
 }
@@ -75,6 +83,10 @@ func (c *client) GetAllMonsters(ctx context.Context) ([]*Monster, error) {
 
 func (c *client) GetMonstersByName(ctx context.Context, names ...string) ([]*Monster, error) {
 	return getMonstersByName(ctx, c, names...)
+}
+
+func (c *client) GetMonstersByWikiName(ctx context.Context, names ...string) ([]*Monster, error) {
+	return getMonstersByWikiName(ctx, c, names...)
 }
 
 func (c *client) GetMonstersThatDrop(ctx context.Context, names ...string) ([]*Monster, error) {

--- a/items.go
+++ b/items.go
@@ -140,13 +140,25 @@ func getItemsByName(ctx context.Context, c *client, names ...string) ([]*Item, e
 	}
 
 	var nameData []string
-	var query string
-
 	for _, name := range names {
 		nameData = append(nameData, fmt.Sprintf(`"%s"`, lib.MakeValidItemName(name)))
 	}
-	query = fmt.Sprintf(`{ "name": { "$in": [%s] }, "duplicate": false }`, strings.Join(nameData, ", "))
 
+	query := fmt.Sprintf(`{ "name": { "$in": [%s] }, "duplicate": false }`, strings.Join(nameData, ", "))
+	return getItemsWhere(ctx, c, query)
+}
+
+func getItemsByWikiName(ctx context.Context, c *client, names ...string) ([]*Item, error) {
+	if c.client == nil {
+		return nil, errors.New("no client configured")
+	}
+
+	var nameData []string
+	for _, name := range names {
+		nameData = append(nameData, fmt.Sprintf(`"%s"`, name))
+	}
+
+	query := fmt.Sprintf(`{ "wiki_name": { "$in": [%s] }, "duplicate": false }`, strings.Join(nameData, ", "))
 	return getItemsWhere(ctx, c, query)
 }
 

--- a/monsters.go
+++ b/monsters.go
@@ -128,15 +128,26 @@ func getMonstersByName(ctx context.Context, c *client, names ...string) ([]*Mons
 	}
 
 	var nameData []string
-	var query string
-
 	for _, name := range names {
 		nameData = append(nameData, fmt.Sprintf(`"%s"`, name))
 	}
-	query = fmt.Sprintf(`{ "name": { "$in": [%s] }, "duplicate": false }`, strings.Join(nameData, ", "))
 
+	query := fmt.Sprintf(`{ "name": { "$in": [%s] }, "duplicate": false }`, strings.Join(nameData, ", "))
 	return getMonstersWhere(ctx, c, query)
+}
 
+func getMonstersByWikiName(ctx context.Context, c *client, names ...string) ([]*Monster, error) {
+	if c.client == nil {
+		return nil, errors.New("no client configured")
+	}
+
+	var nameData []string
+	for _, name := range names {
+		nameData = append(nameData, fmt.Sprintf(`"%s"`, name))
+	}
+
+	query := fmt.Sprintf(`{ "wiki_name": { "$in": [%s] }, "duplicate": false }`, strings.Join(nameData, ", "))
+	return getMonstersWhere(ctx, c, query)
 }
 
 func getMonstersThatDrop(ctx context.Context, c *client, names ...string) ([]*Monster, error) {


### PR DESCRIPTION
some items such as "Rune kiteshield" return multiple items when getting by name because the "name" property is consistent while the "wiki_name" property contains the unique name. so added a method to get items by wiki name